### PR TITLE
Update Makefile.am

### DIFF
--- a/Library/src/Makefile.am
+++ b/Library/src/Makefile.am
@@ -408,7 +408,6 @@ BUILT_SOURCES = \
 	HTBInit.h \
 	HTBTree.h \
 	HTBind.h \
-	HTBind.h \
 	HTBound.h \
 	HTBufWrt.h \
 	HTCache.h \


### PR DESCRIPTION
Removed duplicate HTBind.h entry in Makefile.am that is causing make install to fail.